### PR TITLE
support specifiying b2c policy used when generating the login button see issue 

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -12,6 +12,7 @@ export interface IBotAuthenticatorOptions {
     resumption?: IResumptionProvider;
     successRedirect?: string;
     session?: boolean;
+    b2cPolicy?: string;
 }
 export interface IStrategyOptions {
     callbackURL: string;

--- a/lib/index.js
+++ b/lib/index.js
@@ -125,6 +125,9 @@ class BotAuthenticator {
         return `${this.options.baseUrl}/${this.options.basePath}/${providerName}/callback`;
     }
     authUrl(providerName, state) {
+        if(this.options.b2cPolicy){
+            return `${this.options.baseUrl}/${this.options.basePath}/${providerName}?state=${encodeURIComponent(state)}&p=${encodeURIComponent(this.options.b2cPolicy)}`;          
+        }
         return `${this.options.baseUrl}/${this.options.basePath}/${providerName}?state=${encodeURIComponent(state)}`;
     }
     passport_redirect() {


### PR DESCRIPTION
This change adds the option to supply a B2C policy name in the options  - this is then used when generating the button url for users to click when signing in

see #22 