### PR TITLE
Display Sign-out message instead of throwing error response always

### DIFF
--- a/CSharp/BotAuth/Controllers/CallbackController.cs
+++ b/CSharp/BotAuth/Controllers/CallbackController.cs
@@ -28,7 +28,17 @@ namespace BotAuth.Controllers
         [Route("Callback")]
         public async Task<HttpResponseMessage> Callback()
         {
-            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, new Exception());
+            try
+            {
+                var resp = new HttpResponseMessage(HttpStatusCode.OK);
+                resp.Content = new StringContent($"<html><body>You have been signed out. You can now close this window.</body></html>", System.Text.Encoding.UTF8, @"text/html");
+                return resp;
+            }
+            catch (Exception ex)
+            {
+                // Callback is called with no pending message as a result the login flow cannot be resumed.
+                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ex);
+            }
         }
 
         [HttpGet]


### PR DESCRIPTION
Currently clicking the logout link, throws error response always. Changing it to show the sign-out message on successful sign-out.