### PR TITLE
Corrected magic number auth bug with leading characters in MS Teams

### DIFF
--- a/CSharp/BotAuth/Dialogs/AuthDialog.cs
+++ b/CSharp/BotAuth/Dialogs/AuthDialog.cs
@@ -81,7 +81,7 @@ namespace BotAuth.Dialogs
                             if (text.Contains("</at>"))
                                 text = text.Substring(text.IndexOf("</at>") + 5).Trim();
 
-                            if (text.Length >= 6 && magicNumber.ToString() == text.Substring(0, 6))
+                            if (text.Length >= 6 && text.Length < 18 && text.Contains(magicNumber.ToString()))
                             {
                                 context.UserData.SetValue<string>($"{this.authProvider.Name}{ContextConstants.MagicNumberValidated}", "true");
                                 await context.PostAsync($"Thanks {authResult.UserName}. You are now logged in. ");


### PR DESCRIPTION
Magic number string comparison was thrown off in MS Teams by user potentially pasting leading/trailing carriage return, etc., modified code to  check for "containing" substring instead, while limiting comparison string length (to protect against brute force attempts).

Note: text.Length (comparison string length) limited to 18 to account for possible leading AND trailing characters