### PR TITLE
A Possible solution for Issue #62)

### DIFF
--- a/Node/lib/index.d.ts
+++ b/Node/lib/index.d.ts
@@ -8,6 +8,7 @@ export { IChallengeResponse, IUser };
 export interface IBotAuthenticatorOptions {
     baseUrl: string;
     basePath?: string;
+    servicePath?: string;
     secret: string;
     resumption?: IResumptionProvider;
     successRedirect?: string;

--- a/Node/lib/index.d.ts
+++ b/Node/lib/index.d.ts
@@ -8,7 +8,6 @@ export { IChallengeResponse, IUser };
 export interface IBotAuthenticatorOptions {
     baseUrl: string;
     basePath?: string;
-    servicePath?: string;
     secret: string;
     resumption?: IResumptionProvider;
     successRedirect?: string;

--- a/Node/lib/index.js
+++ b/Node/lib/index.js
@@ -11,6 +11,7 @@ exports.CookieResumption = resumption_1.CookieResumption;
 const consts_1 = require("./consts");
 const defaultOptions = {
     basePath: "botauth",
+    servicePath: "botauth",
     resumption: null,
     secret: null,
     baseUrl: null,
@@ -53,9 +54,9 @@ class BotAuthenticator {
                 done(null, userId);
             });
         }
-        this.server.get(`/${this.options.basePath}/:providerId`, this.options.resumption.persistHandler(), this.passport_redirect());
-        this.server.get(`/${this.options.basePath}/:providerId/callback`, this.passport_callback(), this.options.resumption.restoreHandler(), this.credential_callback());
-        this.server.post(`/${this.options.basePath}/:providerId/callback`, this.passport_callback(), this.options.resumption.restoreHandler(), this.credential_callback());
+        this.server.get(`/${this.options.servicePath}/:providerId`, this.options.resumption.persistHandler(), this.passport_redirect());
+        this.server.get(`/${this.options.servicePath}/:providerId/callback`, this.passport_callback(), this.options.resumption.restoreHandler(), this.credential_callback());
+        this.server.post(`/${this.options.servicePath}/:providerId/callback`, this.passport_callback(), this.options.resumption.restoreHandler(), this.credential_callback());
         this.bot.set("persistConversationData", true);
         this.bot.set("persistUserData", true);
         let lib = new builder.Library(consts_1.DIALOG_LIBRARY);

--- a/Node/lib/index.js
+++ b/Node/lib/index.js
@@ -11,7 +11,6 @@ exports.CookieResumption = resumption_1.CookieResumption;
 const consts_1 = require("./consts");
 const defaultOptions = {
     basePath: "botauth",
-    servicePath: "botauth",
     resumption: null,
     secret: null,
     baseUrl: null,
@@ -37,6 +36,9 @@ class BotAuthenticator {
             if (parsedUrl.protocol !== "https:" || !parsedUrl.slashes || !parsedUrl.hostname) {
                 throw new Error("options.baseUrl must be a valid url and start with 'https://'.");
             }
+        }
+        if(!this.options.servicePath){
+          this.options.servicePath =  this.options.basePath
         }
         if (!this.options.secret) {
             throw new Error("options.secret can not be null");

--- a/Node/test/index-tests.js
+++ b/Node/test/index-tests.js
@@ -42,5 +42,25 @@ describe('BotAuthenticator', function() {
                 let ba = new botauth.BotAuthenticator({}, {}, { baseUrl : "//botauth.azurewebsites.net", secret : "shhhhh" });
             });
         });
+
+        it('should default servicePath to botauth', function() {
+          let server = {
+            use : () => {},
+            get : (route,b,c) => {assert(route.startsWith('/botauth')) },
+            post : (route,b,c,e) => {assert(route.startsWith('/botauth'))}
+          };
+          let ba = new botauth.BotAuthenticator(server, mockBot,  { baseUrl : "https://botauth.azurewebsites.net", secret : "shhhhh" });
+          assert.equal(ba.options.servicePath, 'botauth')
+        });
+
+        it('should override servicePath when set', function() {
+          let server = {
+            use : () => {},
+            get : (route,b,c) => {assert(route.startsWith('/servicePath')) },
+            post : (route,b,c,e) => {assert(route.startsWith('/servicePath'))}
+          };
+          let ba = new botauth.BotAuthenticator(server, mockBot,  { baseUrl : "https://botauth.azurewebsites.net", secret : "shhhhh", servicePath: "servicePath" });
+          assert.equal(ba.options.servicePath, 'servicePath')
+        });
     });
 });


### PR DESCRIPTION
Allows the use of botAuth behind a gateway. (Issue #62)

The addition of the `servicePath` property allows the botauth get and post routes to be different from the callback and auth urls (which use `basePath`). Thus, I can run a bot as service and use a gateway to map the callbacks to the bots  `servicePath`s.